### PR TITLE
Fix building with aeson >= 0.6.2.0 and hashable >= 1.2

### DIFF
--- a/bittorrent.cabal
+++ b/bittorrent.cabal
@@ -116,7 +116,7 @@ library
                      , hashable
 
                        -- Codecs & Serialization
-                     , aeson
+                     , aeson >= 0.6.2.0
                      , base16-bytestring
                      , base32-bytestring >= 0.2
                      , base64-bytestring

--- a/bittorrent.cabal
+++ b/bittorrent.cabal
@@ -113,7 +113,7 @@ library
 
                        -- Hashing
                      , cryptohash == 0.10.*
-                     , hashable
+                     , hashable >= 1.2
 
                        -- Codecs & Serialization
                      , aeson >= 0.6.2.0

--- a/src/Data/Torrent.hs
+++ b/src/Data/Torrent.hs
@@ -137,8 +137,8 @@ instance NFData InfoDict where
   rnf InfoDict {..} = rnf idLayoutInfo
 
 instance Hashable InfoDict where
-  hash = Hashable.hash . idInfoHash
-  {-# INLINE hash #-}
+  hashWithSalt = Hashable.hashUsing idInfoHash
+  {-# INLINE hashWithSalt #-}
 
 -- | Smart constructor: add a info hash to info dictionary.
 infoDictionary :: LayoutInfo -> PieceInfo -> Bool -> InfoDict

--- a/src/Data/Torrent.hs
+++ b/src/Data/Torrent.hs
@@ -123,7 +123,7 @@ data InfoDict = InfoDict
     --   BEP 27: <http://www.bittorrent.org/beps/bep_0027.html>
   } deriving (Show, Read, Eq, Typeable)
 
-$(deriveJSON (L.map Char.toLower . L.dropWhile isLower) ''InfoDict)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map Char.toLower . L.dropWhile isLower) } ''InfoDict)
 
 makeLensesFor
   [ ("idInfoHash"  , "infohash"  )
@@ -239,7 +239,7 @@ instance ToJSON NominalDiffTime where
 instance FromJSON NominalDiffTime where
   parseJSON v = utcTimeToPOSIXSeconds <$> parseJSON v
 
-$(deriveJSON (L.map Char.toLower . L.dropWhile isLower) ''Torrent)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map Char.toLower . L.dropWhile isLower) } ''Torrent)
 
 makeLensesFor
   [ ("tAnnounce"    , "announce"    )

--- a/src/Data/Torrent/Block.hs
+++ b/src/Data/Torrent/Block.hs
@@ -97,7 +97,7 @@ data BlockIx = BlockIx {
   , ixLength :: {-# UNPACK #-} !BlockSize
   } deriving (Show, Eq)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''BlockIx)
+$(deriveJSON defaultOptions { fieldLabelModifier = (L.map toLower . L.dropWhile isLower) } ''BlockIx)
 
 getInt :: S.Get Int
 getInt = fromIntegral <$> S.getWord32be

--- a/src/Data/Torrent/InfoHash.hs
+++ b/src/Data/Torrent/InfoHash.hs
@@ -70,8 +70,8 @@ instance Default InfoHash where
 
 -- | Hash raw bytes. (no encoding)
 instance Hashable InfoHash where
-  hash (InfoHash ih) = Hashable.hash ih
-  {-# INLINE hash #-}
+  hashWithSalt s (InfoHash ih) = hashWithSalt s ih
+  {-# INLINE hashWithSalt #-}
 
 -- | Convert to\/from raw bencoded string. (no encoding)
 instance BEncode InfoHash where

--- a/src/Data/Torrent/Layout.hs
+++ b/src/Data/Torrent/Layout.hs
@@ -125,7 +125,7 @@ data FileInfo a = FileInfo {
                , Functor, Foldable
                )
 
-$(deriveJSON (L.map Char.toLower . L.dropWhile isLower) ''FileInfo)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map Char.toLower . L.dropWhile isLower) } ''FileInfo)
 
 makeLensesFor
   [ ("fiLength", "fileLength")
@@ -210,7 +210,7 @@ data LayoutInfo
     , liDirName  :: !ByteString
     } deriving (Show, Read, Eq, Typeable)
 
-$(deriveJSON (L.map Char.toLower . L.dropWhile isLower) ''LayoutInfo)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map Char.toLower . L.dropWhile isLower) } ''LayoutInfo)
 
 makeLensesFor
   [ ("liFile"   , "singleFile" )

--- a/src/Data/Torrent/Piece.hs
+++ b/src/Data/Torrent/Piece.hs
@@ -117,7 +117,7 @@ data Piece a = Piece
   , pieceData  :: !a
   } deriving (Show, Read, Eq, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''Piece)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map toLower . L.dropWhile isLower) } ''Piece)
 
 instance NFData (Piece a)
 
@@ -160,7 +160,7 @@ data PieceInfo = PieceInfo
     -- ^ Concatenation of all 20-byte SHA1 hash values.
   } deriving (Show, Read, Eq, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''PieceInfo)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map toLower . L.dropWhile isLower) } ''PieceInfo)
 
 -- | Number of bytes in each piece.
 makeLensesFor [("piPieceLength", "pieceLength")] ''PieceInfo

--- a/src/Data/Torrent/Progress.hs
+++ b/src/Data/Torrent/Progress.hs
@@ -62,7 +62,7 @@ data Progress = Progress
   } deriving (Show, Read, Eq)
 
 $(makeLenses ''Progress)
-$(deriveJSON L.tail ''Progress)
+$(deriveJSON defaultOptions { fieldLabelModifier = L.tail } ''Progress)
 
 -- | UDP tracker compatible encoding.
 instance Serialize Progress where

--- a/src/Network/BitTorrent/Core/PeerAddr.hs
+++ b/src/Network/BitTorrent/Core/PeerAddr.hs
@@ -62,7 +62,7 @@ data PeerAddr = PeerAddr {
     , peerPort :: {-# UNPACK #-} !PortNumber
     } deriving (Show, Eq, Ord, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''PeerAddr)
+$(deriveJSON defaultOptions { fieldLabelModifier = (L.map toLower . L.dropWhile isLower) } ''PeerAddr)
 
 -- | The tracker "announce query" compatible encoding.
 instance BEncode PeerAddr where

--- a/src/Network/BitTorrent/Core/PeerId.hs
+++ b/src/Network/BitTorrent/Core/PeerId.hs
@@ -74,8 +74,8 @@ peerIdLen :: Int
 peerIdLen = 20
 
 instance Hashable PeerId where
-  hash = hash . getPeerId
-  {-# INLINE hash #-}
+  hashWithSalt = hashUsing getPeerId
+  {-# INLINE hashWithSalt #-}
 
 instance Serialize PeerId where
   put = putByteString . getPeerId

--- a/src/Network/BitTorrent/Exchange/Status.hs
+++ b/src/Network/BitTorrent/Exchange/Status.hs
@@ -35,7 +35,7 @@ data PeerStatus = PeerStatus {
   } deriving (Show, Eq)
 
 $(makeLenses ''PeerStatus)
-$(deriveJSON L.tail ''PeerStatus)
+$(deriveJSON defaultOptions { fieldLabelModifier = L.tail } ''PeerStatus)
 
 instance Default PeerStatus where
   def = PeerStatus True False

--- a/src/Network/BitTorrent/Tracker/RPC/Message.hs
+++ b/src/Network/BitTorrent/Tracker/RPC/Message.hs
@@ -93,7 +93,7 @@ data Event = Started
              -- ^ To be sent when the peer completes a download.
              deriving (Show, Read, Eq, Ord, Enum, Bounded, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''Event)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map toLower . L.dropWhile isLower) } ''Event)
 
 -- | HTTP tracker protocol compatible encoding.
 instance QueryValueLike Event where
@@ -163,7 +163,7 @@ data AnnounceQuery = AnnounceQuery
    , reqEvent      :: Maybe Event
    } deriving (Show, Eq, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''AnnounceQuery)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map toLower . L.dropWhile isLower) } ''AnnounceQuery)
 
 -- | UDP tracker protocol compatible encoding.
 instance Serialize AnnounceQuery where
@@ -386,7 +386,7 @@ data AnnounceInfo =
      , respWarning     :: !(Maybe Text)
      } deriving (Show, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''AnnounceInfo)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map toLower . L.dropWhile isLower) } ''AnnounceInfo)
 
 -- | HTTP tracker protocol compatible encoding.
 instance BEncode AnnounceInfo where
@@ -524,7 +524,7 @@ data ScrapeEntry = ScrapeEntry {
   , siName       :: !(Maybe Text)
   } deriving (Show, Eq, Typeable)
 
-$(deriveJSON (L.map toLower . L.dropWhile isLower) ''ScrapeEntry)
+$(deriveJSON defaultOptions { fieldLabelModifier =  (L.map toLower . L.dropWhile isLower) } ''ScrapeEntry)
 
 -- | HTTP tracker protocol compatible encoding.
 instance BEncode ScrapeEntry where


### PR DESCRIPTION
### aeson

deriveJSON now takes an Option record instead of a single function. It might be
nicer to define a function that takes the fieldLabelModifier function rather
than doing it inline everywhere but I didn't know where a good place to put that
would be.
### hashable

hashWithSalt is now the minimal implementation
